### PR TITLE
BREAKING,scripts(properties.sh): source termuxrc before exporting

### DIFF
--- a/scripts/properties.sh
+++ b/scripts/properties.sh
@@ -3,6 +3,15 @@
 # coreutils and are clearly not a default part of most Linux installations,
 # or sourcing any other script in our build directories.
 
+# Allow to override setup.
+for f in "${HOME}/.config/termux/termuxrc.sh" "${HOME}/.termux/termuxrc.sh" "${HOME}/.termuxrc"; do
+	if [ -f "$f" ]; then
+		echo "Using builder configuration from '$f'..."
+		. "$f"
+		break
+	fi
+done
+
 TERMUX_SDK_REVISION=9123335
 TERMUX_ANDROID_BUILD_TOOLS_VERSION=33.0.1
 # when changing the above:
@@ -57,12 +66,4 @@ for component in $(jq -r '.[] | .component' ${TERMUX_SCRIPTDIR}/repo.json); do
 	TERMUX_REPO_COMPONENT+=("$component")
 done
 
-# Allow to override setup.
-for f in "${HOME}/.config/termux/termuxrc.sh" "${HOME}/.termux/termuxrc.sh" "${HOME}/.termuxrc"; do
-	if [ -f "$f" ]; then
-		echo "Using builder configuration from '$f'..."
-		. "$f"
-		break
-	fi
-done
 unset f


### PR DESCRIPTION
### Description

In this pull request, the `properties.sh` script is being modified to allow the overriding of setup configurations from specific files in the user's home directory. This change aims to provide users with the flexibility to customize builder configurations within Termux environments.

Changes made in this PR:
- Added a loop to check for override setup configuration files in different locations under the user's home directory.
- If any of the specified files exist, it now echoes a message indicating the use of the configuration from that file and sources it.
- Removed the previous occurrence of the loop that checked and sourced setup configuration files.

These changes enhance the customization options for builder configurations in Termux builds.